### PR TITLE
Added a w3c platform tests runner

### DIFF
--- a/tests/platform-tests/platform-tests-runner.sh
+++ b/tests/platform-tests/platform-tests-runner.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+"""
+Copyright 2017 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+TYPES_REPO="$1"
+
+git -C $TYPES_REPO checkout -- .
+rm -f $TYPES_REPO/trusted-types/index.html
+cat dist/trustedtypes.build.js >> $TYPES_REPO/trusted-types/support/helper.js
+git -C $TYPES_REPO apply < $(dirname $0)/platform-tests.patch
+
+echo "Visit http://127.0.0.1:9999/trusted-types/ to view the tests."
+
+(cd $TYPES_REPO; python -m SimpleHTTPServer 9999; git checkout -- .)
+

--- a/tests/platform-tests/platform-tests.patch
+++ b/tests/platform-tests/platform-tests.patch
@@ -1,0 +1,17 @@
+diff --git a/resources/testharness.js b/resources/testharness.js
+index 087dbf4ff0..9ecc5e290c 100644
+--- a/resources/testharness.js
++++ b/resources/testharness.js
+@@ -2472,7 +2472,11 @@ policies and contribution forms [3].
+         }
+         html += "</tbody></table>";
+         try {
+-            log.lastChild.innerHTML = html;
++            if (window.TrustedHTML) {
++                log.lastChild.innerHTML = TrustedHTML.unsafelyCreate(html);
++            } else {
++                log.lastChild.innerHTML = html;
++            }
+         } catch (e) {
+             log.appendChild(document.createElementNS(xhtml_ns, "p"))
+                .textContent = "Setting innerHTML for the log threw an exception.";


### PR DESCRIPTION
Will start a server to run https://github.com/w3c/web-platform-tests with the polyfill. Needs a checked out copy of `https://github.com/w3c/web-platform-tests` repo, Python and Bash.