### PR TITLE
Moved from Closure goog.require/goog.provide to ES6 modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "extends": "google",
     "parserOptions": {
+        "sourceType": "module",    	
         "ecmaVersion": 6
     }
 }

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -22,7 +22,6 @@ gulp.task('default', ['build']);
 gulp.task('build', function() {
   return gulp.src([
       'src/**/*.js',
-      './node_modules/google-closure-library/closure/goog/base.js',
     ])
     .pipe(closureCompiler({
       compilerPath: './node_modules/google-closure-compiler/compiler.jar',

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -28,7 +28,7 @@ gulp.task('build', function() {
       compilerPath: './node_modules/google-closure-compiler/compiler.jar',
       fileName: 'trustedtypes.build.js',
       compilerFlags: {
-        closure_entry_point: 'trustedtypes.bootstrap',
+        entry_point: './src/bootstrap',
         compilation_level: 'ADVANCED_OPTIMIZATIONS',
         language_in: 'ECMASCRIPT6',
         language_out: 'ECMASCRIPT5',

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -28,7 +28,6 @@ gulp.task('build', function() {
       compilerPath: './node_modules/google-closure-compiler/compiler.jar',
       fileName: 'trustedtypes.build.js',
       compilerFlags: {
-        entry_point: './src/bootstrap',
         compilation_level: 'ADVANCED_OPTIMIZATIONS',
         language_in: 'ECMASCRIPT6',
         language_out: 'ECMASCRIPT5',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,14 +17,10 @@ limitations under the License.
 module.exports = function(config) {
   config.set({
     basePath: '',
-    frameworks: ['jasmine', 'closure'],
+    frameworks: ['browserify', 'jasmine'],
 
     files: [
-      { pattern: 'node_modules/google-closure-library/closure/goog/base.js'},
       { pattern: 'tests/**/*_test.js'},
-      { pattern: 'src/**/*.js', included: false },
-      { pattern: 'node_modules/google-closure-library/closure/goog/deps.js', included: false, served: false },
-      { pattern: 'node_modules/google-closure-library/closure/goog/**/*.js', included: false}
     ],
 
     exclude: [
@@ -32,12 +28,15 @@ module.exports = function(config) {
     ],
 
     preprocessors: {
-      // tests are preprocessed for dependencies (closure) and for iits
-      'tests/**/*.js': ['closure', 'closure-iit'],
-      // source files are preprocessed for dependencies
-      'src/**/*.js': ['closure'],
-      // external deps
-      'node_modules/google-closure-library/closure/goog/deps.js': ['closure-deps']
+      'tests/**/*.js': ['browserify'],
+    },
+
+    browserify : {
+            configure: function browserify(bundle) {
+                bundle.once('prebundle', function prebundle() {
+                    bundle.transform('babelify', {presets: ['env']});
+                });
+            }
     },
 
     reporters: ['progress'],

--- a/package.json
+++ b/package.json
@@ -20,21 +20,25 @@
   "author": "Google Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
+    "babel-preset-env": "^1.6.0",
+    "babelify": "^7.3.0",
+    "browserify": "^14.4.0",
     "eslint": "^4.7.2",
     "eslint-config-google": "^0.9.1",
+    "google-closure-compiler": "^20170910.0.0",
     "gulp": "^3.9.1",
     "gulp-closure-compiler": "^0.4.0",
     "jasmine": "^2.8.0",
     "jasmine-core": "^2.8.0",
     "karma": "^1.7.1",
+    "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.2.0",
-    "karma-closure": "^0.1.1",
     "karma-firefox-launcher": "^1.0.1",
     "karma-jasmine": "^1.1.0",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "watchify": "^3.9.0"
   },
   "dependencies": {
-    "google-closure-library": "^20170910.0.0"
   },
   "pre-commit": [
     "lint",

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -13,19 +13,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.provide('trustedtypes.bootstrap');
+import {TrustedTypesEnforcer} from './enforcement.js';
+import {TrustedTypeConfig} from './data/trustedtypeconfig.js';
 
-goog.require('trustedtypes.TrustedTypesEnforcer');
-goog.require('trustedtypes.data.TrustedTypeConfig');
-
-trustedtypes.bootstrap = function() {
-  const config = new trustedtypes.data.TrustedTypeConfig(
+/**
+ * Bootstraps all trusted types polyfill and their enforcement.
+ */
+export function bootstrap() {
+  const config = new TrustedTypeConfig(
     /* isLoggingEnabled */ true,
     /* isEnforcementEnabled */ true);
 
-  const trustedTypesEnforcer = new trustedtypes.TrustedTypesEnforcer(config);
+  const trustedTypesEnforcer = new TrustedTypesEnforcer(config);
 
   trustedTypesEnforcer.install();
 };
 
-trustedtypes.bootstrap();
+bootstrap();

--- a/src/data/trustedtypeconfig.js
+++ b/src/data/trustedtypeconfig.js
@@ -13,27 +13,28 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.provide('trustedtypes.data.TrustedTypeConfig');
 
 /**
  * A configuration object for trusted type enforcement.
- * @param {boolean} isLoggingEnabled If true enforcement wrappers will log
- *   warnings to the console.
- * @param {boolean} isEnforcementEnabled If true enforcement is enabled at
- *   runtime.
- * @constructor
  */
-trustedtypes.data.TrustedTypeConfig = function(isLoggingEnabled,
-    isEnforcementEnabled) {
+export class TrustedTypeConfig {
   /**
-    * True if logging is enabled.
-    * @type {boolean}
-    */
-  this.isLoggingEnabled = isLoggingEnabled;
+   * @param {boolean} isLoggingEnabled If true enforcement wrappers will log
+   *   warnings to the console.
+   * @param {boolean} isEnforcementEnabled If true enforcement is enabled at
+   *   runtime.
+   */
+  constructor(isLoggingEnabled, isEnforcementEnabled) {
+    /**
+      * True if logging is enabled.
+      * @type {boolean}
+      */
+    this.isLoggingEnabled = isLoggingEnabled;
 
-  /**
-    * True if enforcement is enabled.
-    * @type {boolean}
-    */
-  this.isEnforcementEnabled = isEnforcementEnabled;
-};
+    /**
+      * True if enforcement is enabled.
+      * @type {boolean}
+      */
+    this.isEnforcementEnabled = isEnforcementEnabled;
+  }
+}

--- a/src/enforcement.js
+++ b/src/enforcement.js
@@ -14,37 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-goog.provide('trustedtypes.TrustedTypesEnforcer');
-
-goog.require('trustedtypes.data.TrustedTypeConfig');
-goog.require('trustedtypes.types.TrustedHTML');
-goog.require('trustedtypes.types.TrustedURL');
-goog.require('trustedtypes.types.TrustedScriptURL');
-goog.require('trustedtypes.utils.wrapper');
-
-/**
- * An object for enabling trusted type enforcement.
- * @param {!trustedtypes.data.TrustedTypeConfig} config The configuration for
- * trusted type enforcement.
- * @constructor
- */
-trustedtypes.TrustedTypesEnforcer = function(config) {
-  /**
-   * A configuration for the trusted type enforcement.
-   * @private {!trustedtypes.data.TrustedTypeConfig}
-   */
-  this.config_ = config;
-  /**
-   * @private {Object<string, !function(*): *|undefined>}
-   */
-  this.originalSetters_ = {};
-};
+/* eslint-disable no-unused-vars */
+import {TrustedTypeConfig} from './data/trustedtypeconfig.js';
+import {TrustedHTML} from './types/trustedhtml.js';
+import {TrustedScriptURL} from './types/trustedscripturl.js';
+import {TrustedURL} from './types/trustedurl.js';
+/* eslint-enable no-unused-vars */
+import {installFunction, installSetter} from './utils/wrapper.js';
 
 /**
  * A map of attribute names to allowed types.
  * @type {Object<string, Object<string, !Function>>}
  */
-trustedtypes.TrustedTypesEnforcer.SET_ATTRIBUTE_TYPE_MAP = {
+const SET_ATTRIBUTE_TYPE_MAP = {
     // TODO(slekies): Add event handlers
     // TODO(slekies): add SVG Elements here
     'HTMLAnchorElement': {
@@ -94,234 +76,262 @@ trustedtypes.TrustedTypesEnforcer.SET_ATTRIBUTE_TYPE_MAP = {
     },
 };
 
-
 /**
- * Wraps HTML sinks with an enforcement setter, which will enforce trusted types
- * and do logging, if enabled.
+ * An object for enabling trusted type enforcement.
  */
-trustedtypes.TrustedTypesEnforcer.prototype.install = function() {
-  this.wrapSetter_(Element.prototype, 'innerHTML', window['TrustedHTML']);
-  this.wrapSetter_(Element.prototype, 'outerHTML', window['TrustedHTML']);
-  this.wrapSetter_(HTMLIFrameElement.prototype, 'srcdoc',
-      window['TrustedHTML']);
-  this.wrapSetter_(HTMLScriptElement.prototype, 'src',
-      window['TrustedScriptURL']);
-  this.wrapWithEnforceFunction_(Range.prototype, 'createContextualFragment',
-      window['TrustedHTML'], 0);
-  this.wrapWithEnforceFunction_(Element.prototype, 'insertAdjacentHTML',
-      window['TrustedHTML'], 1);
-  this.wrapSetAttribute_();
-};
+export class TrustedTypesEnforcer {
+  /**
+   * @param {!TrustedTypeConfig} config The configuration for
+   * trusted type enforcement.
+   */
+  constructor(config) {
+    /**
+     * A configuration for the trusted type enforcement.
+     * @private {!TrustedTypeConfig}
+     */
+    this.config_ = config;
+    /**
+     * @private {Object<string, !function(*): *|undefined>}
+     */
+    this.originalSetters_ = {};
+  }
 
-/**
- * Removes the original setters.
- */
-trustedtypes.TrustedTypesEnforcer.prototype.uninstall = function() {
-  this.restoreSetter_(Element.prototype, 'innerHTML');
-  this.restoreSetter_(Element.prototype, 'outerHTML');
-  this.restoreSetter_(HTMLIFrameElement.prototype, 'srcdoc');
-  this.restoreSetter_(HTMLScriptElement.prototype, 'src');
-  this.restoreFunction_(Range.prototype, 'createContextualFragment');
-  this.restoreFunction_(Element.prototype, 'insertAdjacentHTML');
-  this.restoreFunction_(Element.prototype, 'setAttribute');
-};
+  /**
+   * Wraps HTML sinks with an enforcement setter, which will enforce 
+   * trusted types and do logging, if enabled.
+   */
+  install() {
+    this.wrapSetter_(Element.prototype, 'innerHTML', window['TrustedHTML']);
+    this.wrapSetter_(Element.prototype, 'outerHTML', window['TrustedHTML']);
+    this.wrapSetter_(HTMLIFrameElement.prototype, 'srcdoc',
+        window['TrustedHTML']);
+    this.wrapSetter_(HTMLScriptElement.prototype, 'src',
+        window['TrustedScriptURL']);
+    this.wrapWithEnforceFunction_(Range.prototype, 'createContextualFragment',
+        window['TrustedHTML'], 0);
+    this.wrapWithEnforceFunction_(Element.prototype, 'insertAdjacentHTML',
+        window['TrustedHTML'], 1);
+    this.wrapSetAttribute_();
+  }
 
-/** Wraps set attribute with an enforcement function. */
-trustedtypes.TrustedTypesEnforcer.prototype.wrapSetAttribute_ =
-    function() {
-  let that = this;
-  this.wrapFunction_(
-      Element.prototype,
-      'setAttribute',
-      function(originalFn, ...args) {
-        return that.setAttributeWrapper_
-            .bind(that, this, originalFn)
-              .apply(that, args);
-      });
-};
+  /**
+   * Removes the original setters.
+   */
+  uninstall() {
+    this.restoreSetter_(Element.prototype, 'innerHTML');
+    this.restoreSetter_(Element.prototype, 'outerHTML');
+    this.restoreSetter_(HTMLIFrameElement.prototype, 'srcdoc');
+    this.restoreSetter_(HTMLScriptElement.prototype, 'src');
+    this.restoreFunction_(Range.prototype, 'createContextualFragment');
+    this.restoreFunction_(Element.prototype, 'insertAdjacentHTML');
+    this.restoreFunction_(Element.prototype, 'setAttribute');
+  }
 
-/**
- * Enforces type checking for Element.prototype.setAttribute.
- * @param {!Object} context The context for the call to the original function.
- * @param {!Function} originalFn The original setAttribute function.
- * @return {*}
- */
-trustedtypes.TrustedTypesEnforcer.prototype.setAttributeWrapper_ =
-    function(context, originalFn, ...args) {
-  // Note(slekies): In a normal application constructor should never be null.
-  // However, there are no guarantees. If the constructor is null, we cannot
-  // determine whether a special type is required. In order to not break the
-  // application, we will not do any further type checks and pass the call
-  // to setAttribute.
-  if (context.constructor === null) {
+  /** Wraps set attribute with an enforcement function. */
+  wrapSetAttribute_() {
+    let that = this;
+    this.wrapFunction_(
+        Element.prototype,
+        'setAttribute',
+        /** 
+         * @this {TrustedTypesEnforcer}
+         * @param {!Function<!Function, *>} originalFn
+         * @return {*} 
+         */
+        function(originalFn, ...args) {
+          return that.setAttributeWrapper_
+              .bind(that, this, originalFn)
+                .apply(that, args);
+        });
+  };
+
+  /**
+   * Enforces type checking for Element.prototype.setAttribute.
+   * @param {!Object} context The context for the call to the original function.
+   * @param {!Function} originalFn The original setAttribute function.
+   * @return {*}
+   */
+  setAttributeWrapper_(context, originalFn, ...args) {
+    // Note(slekies): In a normal application constructor should never be null.
+    // However, there are no guarantees. If the constructor is null, we cannot
+    // determine whether a special type is required. In order to not break the
+    // application, we will not do any further type checks and pass the call
+    // to setAttribute.
+    if (context.constructor === null) {
+      return originalFn.apply(context, args);
+    }
+
+    let name = args[0];
+    let type = context.constructor && context.constructor.name &&
+        SET_ATTRIBUTE_TYPE_MAP[context.constructor.name] &&
+        SET_ATTRIBUTE_TYPE_MAP[context.constructor.name][name];
+
+    if (type instanceof Function) {
+      return this.enforce_
+          .call(this, context, 'setAttribute', type, originalFn, 1, args);
+    }
+
     return originalFn.apply(context, args);
   }
 
-  let name = args[0];
-  let type = context.constructor && context.constructor.name &&
-      trustedtypes.TrustedTypesEnforcer.SET_ATTRIBUTE_TYPE_MAP[
-      context.constructor.name] &&
-      trustedtypes.TrustedTypesEnforcer.SET_ATTRIBUTE_TYPE_MAP[
-        context.constructor.name][name];
 
-  if (type instanceof Function) {
-    return this.enforce_
-        .call(this, context, 'setAttribute', type, originalFn, 1, args);
+  /**
+   * Wraps a setter with the enforcement wrapper.
+   * @param {!Object} object The object of the to-be-wrapped property.
+   * @param {string} name The name of the property.
+   * @param {!Function} type The type to enforce.
+   * @param {number} argNumber Number of the argument to enforce the type of.
+   * @private
+   */
+  wrapWithEnforceFunction_(object, name, type, argNumber) {
+    let that = this;
+    this.wrapFunction_(
+        object,
+        name,
+        /** 
+         * @this {TrustedTypesEnforcer}
+         * @param {!Function<!Function, *>} originalFn
+         * @return {*} 
+         */        
+        function(originalFn, ...args) {
+          return that.enforce_.call(that, this, name, type, originalFn,
+                                    argNumber, args);
+        });
   }
 
-  return originalFn.apply(context, args);
-};
 
+  /**
+   * Wraps an existing function with a given function body and stores the 
+   * original function.
+   * @param {!Object} object The object of the to-be-wrapped property.
+   * @param {string} name The name of the property.
+   * @param {!Function<!Function, *>} functionBody The wrapper function.
+   */
+  wrapFunction_(object, name, functionBody) {
+    let originalFn = /** @type function(*):* */ (
+        Object.getOwnPropertyDescriptor(object, name).value);
 
-/**
- * Wraps a setter with the enforcement wrapper.
- * @param {!Object} object The object of the to-be-wrapped property.
- * @param {string} name The name of the property.
- * @param {!Function} type The type to enforce.
- * @param {number} argNumber Number of the argument to enforce the type of.
- * @private
- */
-trustedtypes.TrustedTypesEnforcer.prototype.wrapWithEnforceFunction_ =
-    function(object, name, type, argNumber) {
-  let that = this;
-  this.wrapFunction_(
-      object,
-      name,
-      function(originalFn, ...args) {
-        return that.enforce_.call(that, this, name, type, originalFn, argNumber,
-            args);
-      });
-};
-
-
-/**
- * Wraps an existing function with a given function body and stores the original
- * function.
- * @param {!Object} object The object of the to-be-wrapped property.
- * @param {string} name The name of the property.
- * @param {!Function<!Function, *>} functionBody The wrapper function.
- */
-trustedtypes.TrustedTypesEnforcer.prototype.wrapFunction_ =
-    function(object, name, functionBody) {
-  let originalFn = /** @type function(*):* */ (
-      Object.getOwnPropertyDescriptor(object, name).value);
-
-  if (!(originalFn instanceof Function)) {
-    throw new TypeError(
-        'Property ' + name + ' on object' + object + ' is not a function');
-  }
-
-  let key = this.getKey_(object, name);
-  if (this.originalSetters_[key]) {
-    throw new Error('TrustedTypesEnforcer: Double installation detected');
-  }
-  trustedtypes.utils.wrapper.installFunction(
-      object, name, function(...args) {
-  return functionBody.bind(this, originalFn).apply(this, args);
-});
-  this.originalSetters_[key] = originalFn;
-};
-
-/**
- * Wraps a setter with the enforcement wrapper.
- * @param {!Object} object The object of the to-be-wrapped property.
- * @param {string} name The name of the property.
- * @param {!Function} type The type to enforce.
- * @private
- */
-trustedtypes.TrustedTypesEnforcer.prototype.wrapSetter_ =
-    function(object, name, type) {
-  let originalSetter = Object.getOwnPropertyDescriptor(object, name).set;
-  let key = this.getKey_(object, name);
-  if (this.originalSetters_[key]) {
-    throw new Error('TrustedTypesEnforcer: Double installation detected');
-  }
-  let that = this;
-  trustedtypes.utils.wrapper.installSetter(
-      object,
-      name,
-      function(value) {
-        that.enforce_.call(that, this, name, type, originalSetter, 0, [value]);
-      });
-  this.originalSetters_[key] = originalSetter;
-};
-
-/**
- * Restores the original setter for the property, as encountered during
- * install().
- * @param {!Object} object The object of the to-be-wrapped property.
- * @param {string} name The name of the property.
- * @private
- */
-trustedtypes.TrustedTypesEnforcer.prototype.restoreSetter_ =
-    function(object, name) {
-  let key = this.getKey_(object, name);
-  if (!this.originalSetters_[key]) {
-    throw new Error(
-        'TrustedTypesEnforcer: Cannot restore (double uninstallation?)');
-  }
-  trustedtypes.utils.wrapper.installSetter(object, name,
-      this.originalSetters_[key]);
-  delete this.originalSetters_[key];
-};
-
-/**
- * Restores the original method of an object, as encountered during install().
- * @param {!Object} object The object of the to-be-wrapped property.
- * @param {string} name The name of the property.
- * @private
- */
-trustedtypes.TrustedTypesEnforcer.prototype.restoreFunction_ =
-    function(object, name) {
-  let key = this.getKey_(object, name);
-  if (!this.originalSetters_[key]) {
-    throw new Error(
-        'TrustedTypesEnforcer: Cannot restore (double uninstallation?)');
-  }
-  trustedtypes.utils.wrapper.installFunction(object, name,
-      this.originalSetters_[key]);
-  delete this.originalSetters_[key];
-};
-
-/**
- * Returns the key name for caching original setters.
- * @param {!Object} object The object of the to-be-wrapped property.
- * @param {string} name The name of the property.
- * @return {string} Key name.
- * @private
- */
-trustedtypes.TrustedTypesEnforcer.prototype.getKey_ = function(object, name) {
-  return '' + object.constructor.name + '-' + name;
-};
-
-/**
- * Logs and enforces TrustedTypes depending on the given configuration.
- * @param {!Object} context The object that the setter is called for.
- * @param {string} propertyName The name of the property.
- * @param {!Function} typeToEnforce The type to enforce.
- * @param {!function(*): *|undefined} originalSetter Original setter.
- * @param {number} argNumber Number of argument to enforce the type of.
- * @param {Array} args Arguments.
- * @return {*}
- * @private
- */
-trustedtypes.TrustedTypesEnforcer.prototype.enforce_ =
-    function(context, propertyName, typeToEnforce, originalSetter, argNumber,
-             args) {
-  let value = args[argNumber];
-  if (!(value instanceof typeToEnforce)) {
-    let message = 'Failed to set ' + propertyName + ' property on ' +
-        ('' + context || context.constructor.name) +
-        ': This document requires `' + (typeToEnforce.name) + '` assignment.';
-
-    if (this.config_.isLoggingEnabled) {
-      console.warn(message, propertyName, context, typeToEnforce, value);
+    if (!(originalFn instanceof Function)) {
+      throw new TypeError(
+          'Property ' + name + ' on object' + object + ' is not a function');
     }
 
-    if (this.config_.isEnforcementEnabled) {
-      throw new TypeError(message);
+    let key = this.getKey_(object, name);
+    if (this.originalSetters_[key]) {
+      throw new Error('TrustedTypesEnforcer: Double installation detected');
     }
+    installFunction(
+        object,
+        name,
+        /**
+         * @this {TrustedTypesEnforcer}
+         * @return {*}
+         */
+        function(...args) {
+          return functionBody.bind(this, originalFn).apply(this, args);
+        });
+    this.originalSetters_[key] = originalFn;
   }
 
-  return originalSetter.apply(context, args);
-};
+  /**
+   * Wraps a setter with the enforcement wrapper.
+   * @param {!Object} object The object of the to-be-wrapped property.
+   * @param {string} name The name of the property.
+   * @param {!Function} type The type to enforce.
+   * @private
+   */
+  wrapSetter_(object, name, type) {
+    let originalSetter = Object.getOwnPropertyDescriptor(object, name).set;
+    let key = this.getKey_(object, name);
+    if (this.originalSetters_[key]) {
+      throw new Error('TrustedTypesEnforcer: Double installation detected');
+    }
+    let that = this;
+    installSetter(
+        object,
+        name,
+        /** 
+         * @this {TrustedTypesEnforcer}
+         * @param {*} value
+         */        
+        function(value) {
+          that.enforce_.call(that, this, name, type, originalSetter, 0,
+                             [value]);
+        });
+    this.originalSetters_[key] = originalSetter;
+  }
+
+  /**
+   * Restores the original setter for the property, as encountered during
+   * install().
+   * @param {!Object} object The object of the to-be-wrapped property.
+   * @param {string} name The name of the property.
+   * @private
+   */
+  restoreSetter_(object, name) {
+    let key = this.getKey_(object, name);
+    if (!this.originalSetters_[key]) {
+      throw new Error(
+          'TrustedTypesEnforcer: Cannot restore (double uninstallation?)');
+    }
+    installSetter(object, name, this.originalSetters_[key]);
+    delete this.originalSetters_[key];
+  }
+
+  /**
+   * Restores the original method of an object, as encountered during install().
+   * @param {!Object} object The object of the to-be-wrapped property.
+   * @param {string} name The name of the property.
+   * @private
+   */
+  restoreFunction_(object, name) {
+    let key = this.getKey_(object, name);
+    if (!this.originalSetters_[key]) {
+      throw new Error(
+          'TrustedTypesEnforcer: Cannot restore (double uninstallation?)');
+    }
+    installFunction(object, name, this.originalSetters_[key]);
+    delete this.originalSetters_[key];
+  }
+
+  /**
+   * Returns the key name for caching original setters.
+   * @param {!Object} object The object of the to-be-wrapped property.
+   * @param {string} name The name of the property.
+   * @return {string} Key name.
+   * @private
+   */
+  getKey_(object, name) {
+    return '' + object.constructor.name + '-' + name;
+  }
+
+  /**
+   * Logs and enforces TrustedTypes depending on the given configuration.
+   * @param {!Object} context The object that the setter is called for.
+   * @param {string} propertyName The name of the property.
+   * @param {!Function} typeToEnforce The type to enforce.
+   * @param {!function(*): *|undefined} originalSetter Original setter.
+   * @param {number} argNumber Number of argument to enforce the type of.
+   * @param {Array} args Arguments.
+   * @return {*}
+   * @private
+   */
+  enforce_(context, propertyName, typeToEnforce, originalSetter, argNumber,
+               args) {
+    let value = args[argNumber];
+    if (!(value instanceof typeToEnforce)) {
+      let message = 'Failed to set ' + propertyName + ' property on ' +
+          ('' + context || context.constructor.name) +
+          ': This document requires `' + (typeToEnforce.name) + '` assignment.';
+
+      if (this.config_.isLoggingEnabled) {
+        console.warn(message, propertyName, context, typeToEnforce, value);
+      }
+
+      if (this.config_.isEnforcementEnabled) {
+        throw new TypeError(message);
+      }
+    }
+    return originalSetter.apply(context, args);
+  }
+}

--- a/src/types/trustedhtml.js
+++ b/src/types/trustedhtml.js
@@ -13,66 +13,66 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.provide('trustedtypes.types.TrustedHTML');
 
 /**
  * A type to represent trusted HTML.
- * @param {string} inner A piece of trusted html.
- * @constructor
  */
-trustedtypes.types.TrustedHTML = function TrustedHTML(inner) {
+export class TrustedHTML {
   /**
-   * A piece of trusted HTML.
-   * @private {string}
+   * @param {string} inner A piece of trusted html.
    */
-  this.inner_ = inner;
-};
+  constructor(inner) {
+    /**
+     * A piece of trusted HTML.
+     * @private {string}
+     */
+    this.inner_ = inner;
+  }
 
-// Workaround for Closure Compiler clearing the function name.
-Object.defineProperty(trustedtypes.types.TrustedHTML, 'name', {
-  get: function() {
+  /**
+   * Returns the HTML as a string.
+   * @return {string}
+   */
+  toString() {
+    return '' + this.inner_;
+  }
+
+  /**
+   * Creates a TrustedHTML instance by HTML-escaping a given string.
+   * @param {string} html
+   * @return {!TrustedHTML}
+   */
+  static escape(html) {
+    let escaped = html.replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;')
+      .replace(/\x00/g, '&#0;');
+    return new TrustedHTML(escaped);
+  }
+
+  /**
+   * Returns a trusted HTML type that contains an unsafe HTML string.
+   * @param {string} html The unsafe string.
+   * @return {!TrustedHTML}
+   */
+  static unsafelyCreate(html) {
+    return new TrustedHTML(html);
+  }
+
+  /**
+   * Name property getter.
+   * Required by the enforcer to work with both the polyfilled and native type.
+   */
+  static get name() {
     return 'TrustedHTML';
-  },
-});
-
-/**
- * Returns a trusted HTML type that contains the HTML escaped string.
- * @param {string} html The string to escape.
- * @return {!trustedtypes.types.TrustedHTML}
- */
-trustedtypes.types.TrustedHTML.escape = function(html) {
-  let escaped = html.replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
-    .replace(/\x00/g, '&#0;');
-  return new trustedtypes.types.TrustedHTML(escaped);
-};
-
-/**
- * Returns a trusted HTML type that contains an unsafe HTML string.
- * @param {string} html The unsafe string.
- * @return {!trustedtypes.types.TrustedHTML}
- */
-trustedtypes.types.TrustedHTML.unsafelyCreate = function(html) {
-  return new trustedtypes.types.TrustedHTML(html);
-};
-
-/**
- * Returns the HTML as a string.
- * @return {string}
- */
-trustedtypes.types.TrustedHTML.prototype.toString = function() {
-  return '' + this.inner_;
-};
+  }
+}
 
 // Make sure Closure compiler exposes the names.
 if (typeof window['TrustedHTML'] === 'undefined') {
-  goog.exportProperty(window, 'TrustedHTML',
-      trustedtypes.types.TrustedHTML);
-  goog.exportProperty(window['TrustedHTML'], 'escape',
-      trustedtypes.types.TrustedHTML.escape);
-  goog.exportProperty(window['TrustedHTML'], 'unsafelyCreate',
-      trustedtypes.types.TrustedHTML.unsafelyCreate);
+  window['TrustedHTML'] = TrustedHTML;
+  window['TrustedHTML']['escape'] = TrustedHTML.escape;
+  window['TrustedHTML']['unsafelyCreate'] = TrustedHTML.unsafelyCreate;
 }

--- a/src/types/trustedscripturl.js
+++ b/src/types/trustedscripturl.js
@@ -13,57 +13,63 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.provide('trustedtypes.types.TrustedScriptURL');
 
 /**
  * A type to represent a trusted URL.
- * @param {string} url The trusted URL.
- * @constructor
  */
-trustedtypes.types.TrustedScriptURL = function TrustedScriptURL(url) {
+export class TrustedScriptURL {
   /**
-   * The trusted URL.
-   * @private {string}
+   * @param {string} url The trusted URL.
+   */  
+  constructor(url) {
+    /**
+     * The trusted URL.
+     * @private {string}
+     */
+    this.url_ = url;
+  }
+
+  /**
+   * Returns a trusted Script URL type that contains an unsafe URL.
+   * @param {string} url The unsafe URL.
+   * @return {!TrustedScriptURL}
    */
-  this.url_ = url;
-};
+  static unsafelyCreate(url) {
+    let parsedUrl = TrustedScriptURL.parse_(url);
+    return new TrustedScriptURL(parsedUrl.href);
+  }
 
-// Workaround for Closure Compiler clearing the function name.
-Object.defineProperty(trustedtypes.types.TrustedScriptURL, 'name', {
-  get: function() {
+  /**
+   * Returns a parsed URL.
+   * @param {string} url The url to parse.
+   * @return {!HTMLAnchorElement} An anchor element containing the url.
+   */
+  static parse_(url) {
+    let aTag = /** @type !HTMLAnchorElement */ (document.createElement('a'));
+    aTag.href = url;
+    return aTag;
+  }
+
+  /**
+   * Returns the script URL as a string.
+   * @return {string}
+   */
+  toString() {
+    return this.url_;
+  }
+
+  /**
+   * Name property getter.
+   * Required by the enforcer to work with both the polyfilled and native type.
+   */
+  static get name() {
     return 'TrustedScriptURL';
-  },
-});
-
-/**
- * Returns a TrustedScriptURL type that contains an unsafe URL string.
- * @param {string} url The unsafe string.
- * @return {!trustedtypes.types.TrustedScriptURL}
- */
-trustedtypes.types.TrustedScriptURL.unsafelyCreate = function(url) {
-  let parsedUrl = trustedtypes.types.TrustedScriptURL.parse_(url);
-  return new trustedtypes.types.TrustedScriptURL(parsedUrl.href);
-};
-
-/**
- * Returns a parsed URL.
- * @param {string} url The url to parse.
- * @return {!HTMLAnchorElement} An anchor element containing the url.
- */
-trustedtypes.types.TrustedScriptURL.parse_ = function(url) {
-  let aTag = /** @type !HTMLAnchorElement */ (document.createElement('a'));
-  aTag.href = url;
-  return aTag;
-};
-
-trustedtypes.types.TrustedScriptURL.prototype.toString = function() {
-  return this.url_;
-};
+  }
+}
 
 // Make sure Closure compiler exposes the names.
 if (typeof window['TrustedScriptURL'] === 'undefined') {
-  goog.exportProperty(window, 'TrustedScriptURL',
-      trustedtypes.types.TrustedScriptURL);
-  goog.exportProperty(window['TrustedScriptURL'], 'unsafelyCreate',
-      trustedtypes.types.TrustedScriptURL.unsafelyCreate);
+  window['TrustedScriptURL'] = TrustedScriptURL;
+  window['TrustedScriptURL']['unsafelyCreate'] =
+      TrustedScriptURL.unsafelyCreate;
 }

--- a/src/types/trustedurl.js
+++ b/src/types/trustedurl.js
@@ -13,73 +13,78 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.provide('trustedtypes.types.TrustedURL');
 
 /**
  * A type to represent a trusted URL.
- * @param {string} url The trusted URL.
- * @constructor
  */
-trustedtypes.types.TrustedURL = function TrustedURL(url) {
+export class TrustedURL {
   /**
-   * The trusted URL.
-   * @private {string}
+   * @param {string} url The trusted URL.
    */
-  this.url_ = url;
-};
+  constructor(url) {
+    /**
+     * The trusted URL.
+     * @private {string}
+     */
+    this.url_ = url;
+  };
 
-// Workaround for Closure Compiler clearing the function name.
-Object.defineProperty(trustedtypes.types.TrustedURL, 'name', {
-  get: function() {
-    return 'TrustedURL';
-  },
-});
-
-/**
- * Returns a TrustedURL type that contains an unsafe URL string.
- * @param {string} url The unsafe string.
- * @return {!trustedtypes.types.TrustedURL}
- */
-trustedtypes.types.TrustedURL.unsafelyCreate = function(url) {
-  let parsedUrl = trustedtypes.types.TrustedURL.parse_(url);
-  return new trustedtypes.types.TrustedURL(parsedUrl.href);
-};
-
-/**
- * Returns a TrustedURL type. The TrustedURL changes all non HTTP(s) URLs to
- * "about:invalid".
- * @param {string} url The an absolute url.
- * @return {!trustedtypes.types.TrustedURL}
- */
-trustedtypes.types.TrustedURL.create = function(url) {
-  let parsedUrl = trustedtypes.types.TrustedURL.parse_(url);
-  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-    return new trustedtypes.types.TrustedURL('about:invalid');
+  /**
+   * Returns a TrustedURL type that contains an unsafe URL string.
+   * @param {string} url The unsafe string.
+   * @return {!TrustedURL}
+   */
+  static unsafelyCreate(url) {
+    let parsedUrl = TrustedURL.parse_(url);
+    return new TrustedURL(parsedUrl.href);
   }
 
-  return new trustedtypes.types.TrustedURL(parsedUrl.href);
-};
+  /**
+   * Returns a TrustedURL type. The TrustedURL changes all non HTTP(s) URLs to
+   * "about:invalid".
+   * @param {string} url The an absolute url.
+   * @return {!TrustedURL}
+   */
+  static create(url) {
+    let parsedUrl = TrustedURL.parse_(url);
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return new TrustedURL('about:invalid');
+    }
 
-/**
- * Returns a parsed URL.
- * @param {string} url The url to parse.
- * @return {!HTMLAnchorElement} An anchor element containing the url.
- */
-trustedtypes.types.TrustedURL.parse_ = function(url) {
-  let aTag = /** @type !HTMLAnchorElement */ (document.createElement('a'));
-  aTag.href = url;
-  return aTag;
-};
+    return new TrustedURL(parsedUrl.href);
+  }
 
-trustedtypes.types.TrustedURL.prototype.toString = function() {
-  return this.url_;
-};
+  /**
+   * Returns a parsed URL.
+   * @param {string} url The url to parse.
+   * @return {!HTMLAnchorElement} An anchor element containing the url.
+   */
+  static parse_(url) {
+    let aTag = /** @type !HTMLAnchorElement */ (document.createElement('a'));
+    aTag.href = url;
+    return aTag;
+  }
+
+  /**
+   * Returns the URL as a string.
+   * @return {string}
+   */
+  toString() {
+    return this.url_;
+  }
+
+  /**
+   * Name property getter.
+   * Required by the enforcer to work with both the polyfilled and native type.
+   */
+  static get name() {
+    return 'TrustedURL';
+  }
+}
 
 // Make sure Closure compiler exposes the names.
 if (typeof window['TrustedURL'] === 'undefined') {
-  goog.exportProperty(window, 'TrustedURL', trustedtypes.types.TrustedURL);
-  goog.exportProperty(window['TrustedURL'], 'unsafelyCreate',
-      trustedtypes.types.TrustedURL.unsafelyCreate);
-  goog.exportProperty(window['TrustedURL'], 'create',
-      trustedtypes.types.TrustedURL.create);
+  window['TrustedURL'] = TrustedURL;
+  window['TrustedURL']['unsafelyCreate'] = TrustedURL.unsafelyCreate;
+  window['TrustedURL']['create'] = TrustedURL.create;
 }

--- a/src/utils/wrapper.js
+++ b/src/utils/wrapper.js
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.provide('trustedtypes.utils.wrapper');
 
 /**
  * Installs the setter of a given property.
@@ -21,7 +20,7 @@ goog.provide('trustedtypes.utils.wrapper');
  * @param {string} name The name of the property to wrap.
  * @param {function(*): *|undefined} setter A setter function}
  */
-trustedtypes.utils.wrapper.installSetter = function(object, name, setter) {
+export function installSetter(object, name, setter) {
   Object.defineProperty(object, name, {
     set: setter,
   });
@@ -33,7 +32,7 @@ trustedtypes.utils.wrapper.installSetter = function(object, name, setter) {
  * @param {string} name The name of the property to wrap.
  * @param {function(*): *|undefined} fn A function}
  */
-trustedtypes.utils.wrapper.installFunction = function(object, name, fn) {
+export function installFunction(object, name, fn) {
   Object.defineProperty(object, name, {
     value: fn,
   });

--- a/tests/enforcement_test.js
+++ b/tests/enforcement_test.js
@@ -13,21 +13,24 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.require('trustedtypes.TrustedTypesEnforcer');
-goog.require('trustedtypes.data.TrustedTypeConfig');
-goog.require('trustedtypes.types.TrustedHTML');
+// goog.require('trustedtypes.TrustedTypesEnforcer');
+// goog.require('trustedtypes.data.TrustedTypeConfig');
+// goog.require('trustedtypes.types.TrustedHTML');
+import {TrustedTypeConfig} from '../src/data/trustedtypeconfig.js';
+import {TrustedTypesEnforcer} from '../src/enforcement.js';
+import {TrustedHTML} from '../src/types/trustedhtml.js';
 
 describe('TrustedTypesEnforcer', function() {
   let TEST_HTML = '<b>html</b>';
 
   let TEST_URL = 'http://example.com/script';
 
-  let ENFORCING_CONFIG = new trustedtypes.data.TrustedTypeConfig(
+  let ENFORCING_CONFIG = new TrustedTypeConfig(
       /* isLoggingEnabled */ false,
       /* isEnforcementEnabled */ true);
 
   it('requires calling install to enforce', function() {
-    let enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+    let enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
     let el = document.createElement('div');
 
     expect(function() {
@@ -43,7 +46,7 @@ describe('TrustedTypesEnforcer', function() {
   });
 
   it('allows for uninstalling policies', function() {
-    let enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+    let enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
     let el = document.createElement('div');
     enforcer.install();
 
@@ -67,7 +70,7 @@ describe('TrustedTypesEnforcer', function() {
   });
 
   it('prevents double installation', function() {
-    let enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+    let enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
     enforcer.install();
 
     expect(function() {
@@ -78,7 +81,7 @@ describe('TrustedTypesEnforcer', function() {
   });
 
   it('prevents double uninstallation', function() {
-    let enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+    let enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
     enforcer.install();
     enforcer.uninstall();
     expect(function() {
@@ -90,7 +93,7 @@ describe('TrustedTypesEnforcer', function() {
     let enforcer;
 
     beforeEach(function() {
-      enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+      enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
       enforcer.install();
     });
 
@@ -166,7 +169,7 @@ describe('TrustedTypesEnforcer', function() {
     let enforcer;
 
     beforeEach(function() {
-      enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+      enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
       enforcer.install();
     });
 
@@ -190,8 +193,10 @@ describe('TrustedTypesEnforcer', function() {
   });
 
   describe('enforcement allows type-based assignments', function() {
+    let enforcer;
+
     beforeEach(function() {
-      enforcer = new trustedtypes.TrustedTypesEnforcer(ENFORCING_CONFIG);
+      enforcer = new TrustedTypesEnforcer(ENFORCING_CONFIG);
       enforcer.install();
     });
 

--- a/tests/enforcement_test.js
+++ b/tests/enforcement_test.js
@@ -13,9 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// goog.require('trustedtypes.TrustedTypesEnforcer');
-// goog.require('trustedtypes.data.TrustedTypeConfig');
-// goog.require('trustedtypes.types.TrustedHTML');
 import {TrustedTypeConfig} from '../src/data/trustedtypeconfig.js';
 import {TrustedTypesEnforcer} from '../src/enforcement.js';
 import {TrustedHTML} from '../src/types/trustedhtml.js';

--- a/tests/types/trustedhtml_test.js
+++ b/tests/types/trustedhtml_test.js
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.require('trustedtypes.types.TrustedHTML');
+import {TrustedHTML} from '../../src/types/trustedhtml.js';
+// goog.require('trustedtypes.types.TrustedHTML');
 
 describe('TrustedHTML', function() {
   describe('escape', function() {

--- a/tests/types/trustedhtml_test.js
+++ b/tests/types/trustedhtml_test.js
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {TrustedHTML} from '../../src/types/trustedhtml.js';
-// goog.require('trustedtypes.types.TrustedHTML');
 
 describe('TrustedHTML', function() {
   describe('escape', function() {

--- a/tests/types/trustedscripturl_test.js
+++ b/tests/types/trustedscripturl_test.js
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {TrustedScriptURL} from '../../src/types/trustedscripturl.js';
-// goog.require('trustedtypes.types.TrustedHTML');
-
-// goog.require('trustedtypes.types.TrustedScriptURL');
 
 describe('TrustedScriptURL', function() {
   describe('unsafelyCreate', function() {

--- a/tests/types/trustedscripturl_test.js
+++ b/tests/types/trustedscripturl_test.js
@@ -13,7 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.require('trustedtypes.types.TrustedScriptURL');
+import {TrustedScriptURL} from '../../src/types/trustedscripturl.js';
+// goog.require('trustedtypes.types.TrustedHTML');
+
+// goog.require('trustedtypes.types.TrustedScriptURL');
 
 describe('TrustedScriptURL', function() {
   describe('unsafelyCreate', function() {

--- a/tests/types/trustedurl_test.js
+++ b/tests/types/trustedurl_test.js
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-// goog.require('trustedtypes.types.TrustedURL');
-
 import {TrustedURL} from '../../src/types/trustedurl.js';
 
 describe('TrustedURL', function() {

--- a/tests/types/trustedurl_test.js
+++ b/tests/types/trustedurl_test.js
@@ -13,7 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-goog.require('trustedtypes.types.TrustedURL');
+// goog.require('trustedtypes.types.TrustedURL');
+
+import {TrustedURL} from '../../src/types/trustedurl.js';
 
 describe('TrustedURL', function() {
   describe('create', function() {


### PR DESCRIPTION
ES6 import/export syntax is used to integrate better with different compilers.
Removed the dependency on Closure library.
Tests are now using browserify+babelify to resolve their dependencies.